### PR TITLE
split SetExample -> SetString, SetDoubleExample

### DIFF
--- a/test-cases.yml
+++ b/test-cases.yml
@@ -149,7 +149,7 @@ client:
         - '{"value":{}}'
         # - '{"value":null}'
         #   tag: "!lenient"
-    receiveSetExample:
+    receiveSetStringExample:
       positive:
         - '{"value":[]}'
         - '{"value":["","a","b","c"]}'
@@ -161,6 +161,13 @@ client:
         #   tag: "!lenient"
         # TODO SPEC: behavior for an object declared as a "Set" that receives a list with multiple elements that are equal.
         - '{"value":["a","a"]}'
+    receiveSetDoubleExample:
+      positive:
+        - '{"value":[]}'
+        - '{"value":[1.100, 1.2, 1.3]}'
+        - '{}'
+      negative:
+        - '{"value":[1.1, 1.10, 01.100]}'
     receiveMapExample:
       positive:
         - '{"value":{"key":"value","key2":"value2"}}'

--- a/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -94,9 +94,14 @@ services:
         returns: examples.ListExample
         args: { index: integer }
 
-      receiveSetExample:
-        http: GET /receiveSetExample/{index}
-        returns: examples.SetExample
+      receiveSetStringExample:
+        http: GET /receiveSetStringExample/{index}
+        returns: examples.SetStringExample
+        args: { index: integer }
+
+      receiveSetDoubleExample:
+        http: GET /receiveSetDoubleExample/{index}
+        returns: examples.SetDoubleExample
         args: { index: integer }
 
       receiveMapExample:

--- a/verification-api/src/main/conjure/example-types.conjure.yml
+++ b/verification-api/src/main/conjure/example-types.conjure.yml
@@ -21,10 +21,13 @@ types:
         fields:
           value: list<string>
 
-      SetExample:
+      SetStringExample:
         fields:
-          items: set<string>
-          doubleItems: set<double>
+          value: set<string>
+
+      SetDoubleExample:
+        fields:
+          value: set<double>
 
       MapExample:
         fields:


### PR DESCRIPTION
For consistency, everything else has a 'value' field