### PR TITLE
Bind to 0.0.0.0 instead of 127.0.0.1

### DIFF
--- a/verification-server/src/main.rs
+++ b/verification-server/src/main.rs
@@ -100,8 +100,8 @@ fn main() {
 }
 
 fn start_server(router: Router) {
-    // This is our socket address...
-    let addr = "127.0.0.1:8000".parse().unwrap();
+    // bind to 0.0.0.0 instead of loopback so that requests can be served from docker
+    let addr = "0.0.0.0:8000".parse().unwrap();
 
     let router = Arc::new(router);
 


### PR DESCRIPTION
I tried to use the docker image locally, but I couldn't seem to make connections to it!  Weirdly, connections from inside the image worked fine!