### PR TITLE
[fix] test-cases.conjure.yml uses list<string>

### DIFF
--- a/verification-api/src/main/conjure/test-cases.conjure.yml
+++ b/verification-api/src/main/conjure/test-cases.conjure.yml
@@ -10,17 +10,17 @@ types:
       ClientTestCases:
         fields:
           autoDeserialize: map<EndpointName, PositiveAndNegativeTestCases>
-          singleHeaderService: map<EndpointName, set<string>>
-          singlePathParamService: map<EndpointName, set<string>>
-          singleQueryParamService: map<EndpointName, set<string>>
+          singleHeaderService: map<EndpointName, list<string>>
+          singlePathParamService: map<EndpointName, list<string>>
+          singleQueryParamService: map<EndpointName, list<string>>
 
       EndpointName:
         alias: string
 
       PositiveAndNegativeTestCases:
         fields:
-          positive: set<string> # json strings
-          negative: set<string>
+          positive: list<string> # json strings
+          negative: list<string>
 
       IgnoredTestCases:
         fields:

--- a/verification-api/src/main/java/com/palantir/conjure/compliance/CompileTestCasesJson.java
+++ b/verification-api/src/main/java/com/palantir/conjure/compliance/CompileTestCasesJson.java
@@ -17,6 +17,7 @@ import com.palantir.remoting3.ext.jackson.ObjectMappers;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -59,7 +60,7 @@ public final class CompileTestCasesJson {
                 serviceByName(ir, "SingleQueryParamService"));
     }
 
-    private static long countTestCases(Map<EndpointName, Set<String>> tests) {
+    private static long countTestCases(Map<EndpointName, List<String>> tests) {
         return tests.entrySet().stream()
                 .flatMap(e -> e.getValue().stream())
                 .count();


### PR DESCRIPTION
fixes a mistake introduced in https://github.com/palantir/conjure-verification/pull/20

list<T> is necessary