### PR TITLE
Only persist binary to workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
     - *SAVE_REGISTRY
     - persist_to_workspace:
         root: .
-        paths: [ ./target/release/ ]
+        paths: [ ./target/release/conjure-verification-server ]
 
   publish-docker:
     docker:
@@ -103,7 +103,7 @@ jobs:
     - *SAVE_REGISTRY
     - persist_to_workspace:
         root: .
-        paths: [ ./target/x86_64-apple-darwin ]
+        paths: [ ./target/x86_64-apple-darwin/release/conjure-verification-server ]
     - store_artifacts:
         path: ./target/x86_64-apple-darwin/release/conjure-verification-server
 


### PR DESCRIPTION
This stops persisting dynamic libraries and other transient artifacts, reducing the persist time from 12 seconds to 1 second.
We only need to persist the linux / osx binaries for publishing.