### PR TITLE
KebabCaseObjectExample, SnakeCaseObjectExample

### DIFF
--- a/test-cases.yml
+++ b/test-cases.yml
@@ -333,6 +333,18 @@ client:
     #     - '{}'
     #     - '[]'
     #     - '""'
+    receiveKebabCaseObjectExample:
+      positive:
+      - '{"kebab-cased-field":1}'
+      negative:
+      - '{"kebabCasedField":1}'
+      - '{"kebab_cased_field":1}'
+    receiveSnakeCaseObjectExample:
+      positive:
+      - '{"snake_cased_field":1}'
+      negative:
+      - '{"snakeCasedField":1}'
+      - '{"snake-cased-field":1}'
 
   # single-header-service.conjure.yml
   singleHeaderService:

--- a/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -175,3 +175,13 @@ services:
       #   http: GET /receiveBinaryAliasExample/{index}
       #   returns: examples.BinaryAliasExample
       #   args: { index: integer }
+
+      receiveKebabCaseObjectExample:
+        http: GET /receiveKebabCaseObjectExample/{index}
+        returns: examples.KebabCaseObjectExample
+        args: { index: integer }
+
+      receiveSnakeCaseObjectExample:
+        http: GET /receiveSnakeCaseObjectExample/{index}
+        returns: examples.SnakeCaseObjectExample
+        args: { index: integer }

--- a/verification-api/src/main/conjure/example-types.conjure.yml
+++ b/verification-api/src/main/conjure/example-types.conjure.yml
@@ -116,6 +116,14 @@ types:
             type: StringAliasExample
             docs: docs for alias field
 
+      KebabCaseObjectExample:
+        fields:
+          kebab-cased-field: integer
+
+      SnakeCaseObjectExample:
+        fields:
+          snake_cased_field: integer
+
       # complex union
       Union:
         docs: A type which can either be a StringExample, a set of strings, or an integer.


### PR DESCRIPTION
Conjure prefers object fields to be `camelCase`, but also allows `kebab-case` and `snake_case`.