### PR TITLE
use EndpointName type in confirm service

### DIFF
--- a/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -17,7 +17,7 @@ services:
           to verify that it has been serialized and deserialized properly.
         args:
           endpoint:
-            type: EndpointName
+            type: examples.EndpointName
             docs: The name of the endpoint where the automatic test case request was made.
           index:
             type: integer


### PR DESCRIPTION
/cc @nmiyake 

this is intended to improve the ergonomics of the test harness code, where you are typically looping over the map of `EndpointName`s but then must cast them to a string when using the confirm service.

Not sure if this is a problem in other languages, but in Go you get something like this: 

```go
// type definition
type ClientTestCases struct {
  AutoDeserialize  map[EndpointName]PositiveAndNegativeTestCases
}

// use in test harness code
  for endpointName, cases := range tests.Client.AutoDeserialize {
      // TODO: why isn't the first argument also an endpoint name
      if err := confirmService.Confirm(string(endpointName), i, result); err != nil {
      }
  }
```