### PR TITLE
test-cases verify DoubleAlias NaN and Infinity

### DIFF
--- a/test-cases.yml
+++ b/test-cases.yml
@@ -220,12 +220,19 @@ client:
       positive:
         - '10'
         - '10.0'
-      # TODO: NaN, Infinity
+        - '"NaN"'
+        - '"Infinity"'
+        - '"-Infinity"'
       negative:
         - 'null'
         - '{}'
         - '[]'
         - '""'
+        - '"nan"'
+        - '"NAN"'
+        - '"infinity"'
+        - '"-infinity"'
+        - '"+Infinity"'
     receiveIntegerAliasExample:
       positive:
         - '0'


### PR DESCRIPTION
[RFC 005](
https://github.com/palantir/conjure/blob/develop/docs/rfc/005-handling-double-nan-and-infinity.md) defined the valid double types: NaN/Infinity/-Infinity.

We already have tests that prove clients can handle these cases for raw doubles, but we should also prove that the edge cases also work with double aliases.
