### PR TITLE
[break] ensure all services come from same package

### DIFF
--- a/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -27,7 +27,7 @@ services:
 
   AutoDeserializeService:
     name: Auto Deserialize Service
-    package: com.palantir.conjure.verification
+    package: com.palantir.conjure.verification.server
     default-auth: none
 
     endpoints:


### PR DESCRIPTION
Fixes issue where one of the `conjuer-verification-server-api` services was still being defined with the old package name