### PR TITLE
disable publish on non-tag builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,4 +163,4 @@ workflows:
             - cargo-build-linux
             - cargo-build-osx
             - gradle-build
-          filters: { tags: { only: /.*/ } }
+          filters: { branches: { ignore: /.*/ }, tags: { only: /.*/ } }


### PR DESCRIPTION
## Before this PR
We always ran publish on every build

## After this PR
We only run publish on tag builds