### PR TITLE
[fix] Use proper error when endpoint not found

### DIFF
--- a/verification-server/src/resource.rs
+++ b/verification-server/src/resource.rs
@@ -381,7 +381,12 @@ fn get_endpoint<'a, V>(
     endpoint: &EndpointName,
 ) -> Result<&'a V> {
     map.get(endpoint).ok_or_else(|| {
-        Error::internal_safe("No such endpoint").with_safe_param("endpointName", endpoint)
+        Error::new_safe(
+            "No such endpoint",
+            VerificationError::InvalidEndpointParameter {
+                endpoint_name: endpoint.clone(),
+            },
+        )
     })
 }
 


### PR DESCRIPTION
verification-server was throwing an internal error when a requested endpoint wasn't found in the test cases, now it throws a typed `InvalidEndpointParameter` error.