### PR TITLE
[fix] Really publish verification client

### DIFF
--- a/gradle/publish-rust-dist.gradle
+++ b/gradle/publish-rust-dist.gradle
@@ -44,7 +44,7 @@ variants.each { String variant ->
                 }
             }
             "${variant}DistTarOsx"(MavenPublication) {
-                artifactId "verification-server"
+                artifactId "verification-$variant"
                 artifact (tasks["${variant}DistTarOsx"]) {
                     classifier "osx"
                 }


### PR DESCRIPTION
Missing template in gradle scripts caused the verification-client to be published as the verification-server