### PR TITLE
[improvement] More optional test cases

### DIFF
--- a/verification-client-api/src/main/conjure/auto-deserialize-service.yml
+++ b/verification-client-api/src/main/conjure/auto-deserialize-service.yml
@@ -91,6 +91,16 @@ services:
         returns: examples.OptionalExample
         args: { body: examples.OptionalExample  }
 
+      getOptionalBooleanExample:
+        http: POST /getOptionalBooleanExample
+        returns: examples.OptionalBooleanExample
+        args: { body: examples.OptionalBooleanExample  }
+
+      getOptionalIntegerExample:
+        http: POST /getOptionalIntegerExample
+        returns: examples.OptionalIntegerExample
+        args: { body: examples.OptionalIntegerExample  }
+
       getLongFieldNameOptionalExample:
         http: POST /getLongFieldNameOptionalExample
         returns: examples.LongFieldNameOptionalExample

--- a/verification-client-api/src/main/conjure/example-types.conjure.yml
+++ b/verification-client-api/src/main/conjure/example-types.conjure.yml
@@ -47,6 +47,8 @@ types:
       #     uuids: map<UuidAliasExample, ManyFieldExample>
 
       OptionalExample: { fields: { value: optional<string> } }
+      OptionalBooleanExample: { fields: { value: optional<boolean> } }
+      OptionalIntegerExample: { fields: { value: optional<integer> } }
       LongFieldNameOptionalExample: { fields: { someLongName: optional<string> } }
 
       RawOptionalExample: { alias: optional<integer> }

--- a/verification-client-api/test-cases.yml
+++ b/verification-client-api/test-cases.yml
@@ -191,6 +191,26 @@ server:
       negative:
         - '{"value":{}}'
         - '{"value":[]}'
+    getOptionalBooleanExample:
+      positive:
+        - '{}'
+        - '{"value":null}'
+        - '{"value":true}'
+        - '{"value":false}'
+      negative:
+        - '{"value":{}}'
+        - '{"value":[]}'
+        - '{"value":"true"}'
+    getOptionalIntegerExample:
+      positive:
+        - '{}'
+        - '{"value":null}'
+        - '{"value":0}'
+        - '{"value":1234}'
+      negative:
+        - '{"value":{}}'
+        - '{"value":[]}'
+        - '{"value":"1234"}'
     getLongFieldNameOptionalExample:
       positive:
         - '{}'

--- a/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -115,6 +115,16 @@ services:
         returns: examples.OptionalExample
         args: { index: integer }
 
+      receiveOptionalBooleanExample:
+        http: GET /receiveOptionalBooleanExample/{index}
+        returns: examples.OptionalBooleanExample
+        args: { index: integer }
+
+      receiveOptionalIntegerExample:
+        http: GET /receiveOptionalIntegerExample/{index}
+        returns: examples.OptionalIntegerExample
+        args: { index: integer }
+
       receiveLongFieldNameOptionalExample:
         http: GET /receiveLongFieldNameOptionalExample/{index}
         returns: examples.LongFieldNameOptionalExample

--- a/verification-server-api/src/main/conjure/example-types.conjure.yml
+++ b/verification-server-api/src/main/conjure/example-types.conjure.yml
@@ -47,6 +47,8 @@ types:
       #     uuids: map<UuidAliasExample, ManyFieldExample>
 
       OptionalExample: { fields: { value: optional<string> } }
+      OptionalBooleanExample: { fields: { value: optional<boolean> } }
+      OptionalIntegerExample: { fields: { value: optional<integer> } }
       LongFieldNameOptionalExample: { fields: { someLongName: optional<string> } }
 
       RawOptionalExample: { alias: optional<integer> }

--- a/verification-server-api/test-cases.yml
+++ b/verification-server-api/test-cases.yml
@@ -191,6 +191,26 @@ client:
       negative:
         - '{"value":{}}'
         - '{"value":[]}'
+    receiveOptionalBooleanExample:
+      positive:
+        - '{}'
+        - '{"value":null}'
+        - '{"value":true}'
+        - '{"value":false}'
+      negative:
+        - '{"value":{}}'
+        - '{"value":[]}'
+        - '{"value":"true"}'
+    receiveOptionalIntegerExample:
+      positive:
+        - '{}'
+        - '{"value":null}'
+        - '{"value":0}'
+        - '{"value":1234}'
+      negative:
+        - '{"value":{}}'
+        - '{"value":[]}'
+        - '{"value":"1234"}'
     receiveLongFieldNameOptionalExample:
       positive:
         - '{}'


### PR DESCRIPTION
## Before this PR

All our optional-related tests used one Conjure definition:
```yml
      OptionalExample: { fields: { value: optional<string> } }
```

However, conjure-java has logic to specialise certain optionals to avoid unnecessary boxing, e.g. using [`OptionalInt`](https://docs.oracle.com/javase/8/docs/api/java/util/OptionalInt.html) and OptionalBoolean

## After this PR

We have test cases for this OptionalInt case.  Note that java doesn't actually have an OptionalBoolean, but I think it's probably worth testing anyway just so that implementations don't get confused with the falsyness of 'null' vs 'false'.
