### PR TITLE
[improvement] verification-server's test cases cover enums as map keys

### DIFF
--- a/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
+++ b/verification-server-api/src/main/conjure/auto-deserialize-service.conjure.yml
@@ -417,7 +417,7 @@ services:
         returns: examples.MapUuidAliasExample
         args: { index: integer }
 
-      receiveMapEnumExample:
-        http: GET /receiveMapEnumExample/{index}
-        returns: examples.MapEnumExample
+      receiveMapEnumAliasExample:
+        http: GET /receiveMapEnumAliasExample/{index}
+        returns: examples.MapEnumAliasExample
         args: { index: integer }

--- a/verification-server-api/src/main/conjure/example-types.conjure.yml
+++ b/verification-server-api/src/main/conjure/example-types.conjure.yml
@@ -150,5 +150,5 @@ types:
         alias: map<string, boolean>
       MapUuidAliasExample:
         alias: map<uuid, boolean>
-      MapEnumExample:
+      MapEnumAliasExample:
         alias: map<EnumExample, boolean>

--- a/verification-server-api/test-cases.yml
+++ b/verification-server-api/test-cases.yml
@@ -668,7 +668,7 @@ client:
         - '{}'
         # - '{"d6ddc1ac-3c1b-11e8-b467-0ed5f89f718b": true}'
       negative: []
-    receiveMapEnumExample:
+    receiveMapEnumAliasExample:
       positive:
         - '{}'
         - '{"ONE": true, "TWO": false}'


### PR DESCRIPTION
## Before this PR

No coverage for this feature.

## After this PR

The verification-server now has coverage for this.  verification-client remains unchanged.

cc @dansanduleac 