### PR TITLE
[fix] test proves that json deserializes nicely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,6 +309,7 @@ dependencies = [
  "pretty_env_logger 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-conjure 0.1.4",
+ "serde-conjure-derive 0.1.4",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_plain 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/verification-client-api/src/main/java/com/palantir/conjure/verification/client/CompileVerificationClientTestCasesJson.java
+++ b/verification-client-api/src/main/java/com/palantir/conjure/verification/client/CompileVerificationClientTestCasesJson.java
@@ -18,7 +18,6 @@ package com.palantir.conjure.verification.client;
 
 import static java.util.stream.Collectors.toSet;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.Sets;
@@ -45,9 +44,7 @@ public final class CompileVerificationClientTestCasesJson {
 
         ServerTestCases serverTestCases = testCases.getServer();
 
-        ObjectMapper jsonMapper = ObjectMappers.newServerObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        ObjectMapper jsonMapper = ObjectMappers.newServerObjectMapper();
 
         long total = countPositiveAndNegative(serverTestCases.getAutoDeserialize());
 

--- a/verification-server-api/src/main/java/com/palantir/conjure/verification/server/CompileVerificationServerTestCasesJson.java
+++ b/verification-server-api/src/main/java/com/palantir/conjure/verification/server/CompileVerificationServerTestCasesJson.java
@@ -6,7 +6,6 @@ package com.palantir.conjure.verification.server;
 
 import static java.util.stream.Collectors.toSet;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.Sets;
@@ -34,9 +33,7 @@ public final class CompileVerificationServerTestCasesJson {
 
         ClientTestCases clientTestCases = testCases.getClient();
 
-        ObjectMapper jsonMapper = ObjectMappers.newServerObjectMapper()
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        ObjectMapper jsonMapper = ObjectMappers.newServerObjectMapper();
 
         long total = countPositiveAndNegative(clientTestCases.getAutoDeserialize())
                 + countTestCases(clientTestCases.getSingleHeaderService())

--- a/verification-server/Cargo.toml
+++ b/verification-server/Cargo.toml
@@ -11,6 +11,7 @@ conjure-verification-http-server = { path = "../verification-http-server" }
 conjure-verification-error = { path = "../verification-error" }
 conjure-verification-error-derive = { path = "../verification-error-derive" }
 serde-conjure = { path = "../serde-conjure" }
+serde-conjure-derive = { path = "../serde-conjure-derive" }
 
 bytes = "0.4"
 derive_more = "0.11"

--- a/verification-server/src/main.rs
+++ b/verification-server/src/main.rs
@@ -30,12 +30,12 @@ extern crate hyper;
 extern crate mime;
 extern crate pretty_env_logger;
 extern crate serde_conjure;
-#[macro_use]
-extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_plain;
 extern crate serde_yaml;
 extern crate typed_headers;
+#[macro_use]
+extern crate serde_conjure_derive;
 
 use conjure::ir::Conjure;
 use conjure_verification_common::conjure;


### PR DESCRIPTION
## Before this PR

The server was unable to deserialize test-cases.json due to missing negative test cases.

## After this PR

The negative test cases are now always included. (Stopgap fix until we can improve the deserialization macro)

```json
      "receiveOptionalAnyAliasExample" : {
        "positive" : [ "null", "0", "\"content\"", "true", "[1,2,3]", "{\"key\":3}" ],
        "negative" : [ ]
      },
```
