### PR TITLE
[fix] Fix verification-client url for outgoing requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,7 @@ dependencies = [
  "conjure-verification-http 0.1.0",
  "conjure-verification-http-client 0.1.0",
  "conjure-verification-http-server 0.1.0",
+ "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/verification-client/Cargo.toml
+++ b/verification-client/Cargo.toml
@@ -16,6 +16,7 @@ serde-conjure-derive = { path = "../serde-conjure-derive" }
 
 bytes = "0.4"
 derive_more = "0.11"
+derive-new = "0.5"
 uuid = { version = "0.6", features = ["v4", "serde"] }
 either = "1.5"
 futures = "0.1.21"

--- a/verification-client/src/main.rs
+++ b/verification-client/src/main.rs
@@ -40,6 +40,9 @@ extern crate serde_conjure_derive;
 #[macro_use]
 extern crate serde_derive;
 #[cfg_attr(test, macro_use)]
+#[cfg(test)]
+extern crate derive_new;
+#[cfg_attr(test, macro_use)]
 extern crate serde_json;
 extern crate serde_plain;
 extern crate serde_value;

--- a/verification-client/src/resource.rs
+++ b/verification-client/src/resource.rs
@@ -105,7 +105,7 @@ impl VerificationClientResource {
         let endpoint = &client_request.endpoint_name;
 
         let client = VerificationClientResource::construct_client(&client_request.base_url)?;
-        let mut builder = client.post("/:endpoint");
+        let mut builder = client.post("/body/:endpoint");
         builder.param("endpoint", &endpoint.0);
         builder.headers_mut().insert(
             ACCEPT,


### PR DESCRIPTION
## Before this PR

#88 introduced a regression by changing the base-path of verification-client-api's `AutoDeserializeService`.

## After this PR

verification-client correctly prepends `/body` to requests against the "AutoDeserializeService".