### PR TITLE
Test cases for enums as body, header, query, path-param

### DIFF
--- a/docs/verification_client.md
+++ b/docs/verification_client.md
@@ -58,7 +58,7 @@ Note: For negative [Body tests][], the index should be set to (number of positiv
 Service definitions are generated into `/verification-client-api/src/main/conjure/generated` by running
 
 ```bash
-./gradlew generateConjureDefinitions
+./gradlew generate
 ```
 
 #### Body tests

--- a/docs/verification_server.md
+++ b/docs/verification_server.md
@@ -22,7 +22,7 @@ That will generate a file `/verification-server-api/build/test-cases.json`, whic
 Service definitions are generated into `/verification-server-api/src/main/conjure/generated` by running
 
 ```bash
-./gradlew generateConjureDefinitions
+./gradlew generate
 ```
 
 ### Prerequisites

--- a/example-types.conjure.yml
+++ b/example-types.conjure.yml
@@ -62,6 +62,7 @@ types:
         values:
           - ONE
           - TWO
+          - ONE_HUNDRED
       Enum:
         values:
           - ONE

--- a/master-test-cases.yml
+++ b/master-test-cases.yml
@@ -1,3 +1,9 @@
+###
+# master-test-cases.yml contains sample strings which should either deserialize successfully or fail to
+# deserialize into Conjure types specified in the examples-types.conjure.yml file.
+# Run `./gradlew generate` to programmatically create corresponding Conjure YML for services.
+###
+
 body:
   # primitives
   - type: BearerTokenExample
@@ -134,6 +140,26 @@ body:
     negative:
         - '{"value":null}'
 
+  # named types
+  - type: EnumExample
+    positive:
+        - '"ONE"'
+        - '"one"'
+        - '"TWO"'
+        - '"two"'
+        - '"ONE_HUNDRED"'
+        - '"one_hundred"'
+        - '"THIS_IS_UNKNOWN"'
+    negative:
+        - ''
+        - '[]'
+        - '{}'
+        - '0'
+        - '"!!!"'
+        - '"one-hundred"'
+        - 'UNQUOTED'
+        - 'ONE'
+        - 'one-hundred'
 
     # collections
   - type: ListExample
@@ -716,6 +742,12 @@ singleHeaderParam:
   positive:
     - '""'
     - '"hello"'
+- type: EnumExample
+  positive:
+    - '"ONE"'
+    - '"TWO"'
+    - '"ONE_HUNDRED"'
+    - '"UNKNOWN_VARIANT"'
 
 singlePathParam:
 - type: boolean
@@ -758,6 +790,12 @@ singlePathParam:
   positive:
     - '""'
     - '"hello"'
+- type: EnumExample
+  positive:
+    - '"ONE"'
+    - '"TWO"'
+    - '"ONE_HUNDRED"'
+    - '"UNKNOWN_VARIANT"'
 
 singleQueryParam:
 - type: boolean
@@ -804,3 +842,9 @@ singleQueryParam:
   positive:
     - '""'
     - '"hello"'
+- type: EnumExample
+  positive:
+    - '"ONE"'
+    - '"TWO"'
+    - '"ONE_HUNDRED"'
+    - '"UNKNOWN_VARIANT"'


### PR DESCRIPTION
## Before this PR

conjure-java's Undertow work needs dedicated enum support (https://github.com/palantir/conjure-java/pull/159), but there aren't currently test cases to cover this.

## After this PR

We have test cases for plain enums.

https://palantir.github.io/conjure/#/docs/spec/conjure_definitions?id=enumtypedefinition

cc @cakofony 