### PR TITLE
Fix MapEnumExampleAlias test case

### DIFF
--- a/master-test-cases.yml
+++ b/master-test-cases.yml
@@ -690,8 +690,10 @@ body:
   - type: MapEnumExampleAlias
     positive:
         - '{"ONE": "", "TWO": ""}'
-        - '{"ONE": "", "TWO": "", "BAD VARIANT": ""}'
-
+        - '{"ONE": "", "TWO": "", "UNKNOWN_VARIANT": ""}'
+    # https://github.com/palantir/conjure/issues/193
+    # negative:
+    #     - '{"ONE": "", "TWO": "", "INVALID CHARS": ""}'
 singleHeaderParam:
 - type: bearertoken
   positive:


### PR DESCRIPTION
Enum values are not allowed to use spaces per the spec.
This change does not add the negative test while we wait on
a resolution to https://github.com/palantir/conjure/issues/193