### PR TITLE
Fix contradictory 'any' nullability verification

### DIFF
--- a/example-types.conjure.yml
+++ b/example-types.conjure.yml
@@ -118,6 +118,7 @@ types:
       ListStringAliasExample: { alias: list<string> }
       ListUuidAliasExample: { alias: list<uuid> }
       ListAnyAliasExample: { alias: list<any> }
+      ListOptionalAnyAliasExample: { alias: list<optional<any>> }
 
       SetBearerTokenAliasExample: { alias: set<bearertoken> }
       SetBinaryAliasExample: { alias: set<binary> }
@@ -130,6 +131,7 @@ types:
       SetStringAliasExample: { alias: set<string> }
       SetUuidAliasExample: { alias: set<uuid> }
       SetAnyAliasExample: { alias: set<any> }
+      SetOptionalAnyAliasExample: { alias: set<optional<any>> }
 
       MapBearerTokenAliasExample:
         alias: map<bearertoken, boolean>

--- a/master-test-cases.yml
+++ b/master-test-cases.yml
@@ -553,9 +553,16 @@ body:
   - type: ListAnyAliasExample
     positive:
         - '[]'
-        - '[null, 0, "content", true, [1,2,3], {"key":3}]'
+        - '[0, "content", true, [1,2,3], {"key":3}]'
     negative:
         - 'null'
+        - '[null]'
+  - type: ListOptionalAnyAliasExample
+    positive:
+      - '[]'
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]'
+    negative:
+      - 'null'
   - type: SetBearerTokenAliasExample
     positive:
         - '[]'
@@ -621,9 +628,16 @@ body:
   - type: SetAnyAliasExample
     positive:
         - '[]'
-        - '[null, 0, "content", true, [1,2,3], {"key":3}]'
+        - '[0, "content", true, [1,2,3], {"key":3}]'
     negative:
         - 'null'
+        - '[null]'
+  - type: SetOptionalAnyAliasExample
+    positive:
+      - '[]'
+      - '[null, 0, "content", true, [1,2,3], {"key":3}]'
+    negative:
+      - 'null'
   - type: MapBearerTokenAliasExample
     positive:
         - '{}'


### PR DESCRIPTION
The 'AnyExample' test lists negative test '{"value":null}' however
ListAnyAliasExample and SetAnyAliasExample both listed positive
cases for JSON arrays including null values.