### PR TITLE
Fix: Don't throw on streaming responses

### DIFF
--- a/verification-http-server/src/handler.rs
+++ b/verification-http-server/src/handler.rs
@@ -344,7 +344,7 @@ impl SyncHandler {
                 Body::Fixed(bytes)
             }
             // handle tracking response_size for streaming body
-            Body::Streaming(write_body) => Body::Streaming(write_body)
+            Body::Streaming(write_body) => Body::Streaming(write_body),
         };
 
         response

--- a/verification-http-server/src/handler.rs
+++ b/verification-http-server/src/handler.rs
@@ -277,7 +277,6 @@ impl SyncHandler {
                 return;
             }
             Body::Fixed(bytes) => {
-                response_size.store(bytes.len(), Ordering::SeqCst);
                 let mut response = hyper::Response::new(hyper::Body::from(bytes));
                 *response.status_mut() = raw_response.status;
                 *response.headers_mut() = raw_response.headers;
@@ -344,12 +343,8 @@ impl SyncHandler {
                 response_size.store(bytes.len(), Ordering::SeqCst);
                 Body::Fixed(bytes)
             }
-            Body::Streaming(_write_body) =>
-                unimplemented!()
-//                Body::Streaming(Box::new(SizeTrackingWriteBody {
-//                write_body: write_body,
-//                response_size: response_size.clone(),
-//            })),
+            // handle tracking response_size for streaming body
+            Body::Streaming(write_body) => Body::Streaming(write_body)
         };
 
         response


### PR DESCRIPTION
## Before this PR
We threw on streaming responses not being able to track response size

## After this PR
==COMMIT_MSG==
Don't attempt to track streaming response body size
==COMMIT_MSG==

## Possible downsides?
N/A, the size was only used for our logging which we ripped out before open sourcing.
