### PR TITLE
Fix: Send deserialized json bytes for binary types

### DIFF
--- a/changelog/@unreleased/pr-273.v2.yml
+++ b/changelog/@unreleased/pr-273.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Send deserialized bytes for binary types
+  links:
+  - https://github.com/palantir/conjure-verification/pull/273

--- a/verification-common/src/conjure/value/mod.rs
+++ b/verification-common/src/conjure/value/mod.rs
@@ -92,4 +92,4 @@ pub enum UnionVariant {
 
 /// Deserialized only from a base-64 encoded string.
 #[derive(Serialize, Debug, PartialEq, PartialOrd, Eq, Ord)]
-pub struct Binary(Vec<u8>);
+pub struct Binary(pub Vec<u8>);

--- a/verification-server/src/resource.rs
+++ b/verification-server/src/resource.rs
@@ -175,10 +175,10 @@ impl SpecTestResource {
 
             let cases = get_endpoint(&resource.test_cases.auto_deserialize, &endpoint)?;
             return get_test_case_at_index(cases, &index)?
-                .map_left(|case| match case.0.value {
-                    ConjureValue::Primitive(ConjurePrimitiveValue::Binary(_)) => {
+                .map_left(|case| match &case.0.value {
+                    ConjureValue::Primitive(ConjurePrimitiveValue::Binary(binary)) => {
                         StreamingResponse {
-                            data: case.0.text.as_str().into(),
+                            data: binary.0.to_owned(),
                         }.into_response(request)
                     }
                     _ => SpecTestResource::response_non_streaming(case.0.text.as_str(), request),


### PR DESCRIPTION
## Before this PR
We would send raw json bytes for binary endpoint

## After this PR
==COMMIT_MSG==
Send deserialized bytes for binary types
==COMMIT_MSG==

## Possible downsides?
This was a bug
