### PR TITLE
Remove empty string path param tests

### DIFF
--- a/changelog/@unreleased/pr-314.v2.yml
+++ b/changelog/@unreleased/pr-314.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Removed two test cases that were impossible to satisfy.
+  links:
+  - https://github.com/palantir/conjure-verification/pull/314

--- a/master-test-cases.yml
+++ b/master-test-cases.yml
@@ -788,7 +788,6 @@ singlePathParam:
     - '9007199254740991'
 - type: string
   positive:
-    - '""'
     - '"hello"'
 - type: uuid
   positive:
@@ -796,7 +795,6 @@ singlePathParam:
     - '"80e6dd13-5f42-4e33-ad18-f73875540c8b"' # UUID v4
 - type: AliasString
   positive:
-    - '""'
     - '"hello"'
 - type: EnumExample
   positive:


### PR DESCRIPTION
Closes #300 

These are ignored by every single consumer of the verification server:
https://github.com/palantir/conjure-rust-runtime/blob/master/conjure-verification/ignored-test-cases.yml#L99-L104
https://github.com/palantir/conjure-java-runtime/blob/develop/conjure-java-client-verifier/src/test/resources/ignored-test-cases.retrofit.yml#L123-L127
https://github.com/palantir/conjure-java-runtime/blob/develop/conjure-java-client-verifier/src/test/resources/ignored-test-cases.jersey.yml#L86-L90
https://github.com/palantir/conjure-typescript-runtime/blob/b1005c04a051fc44907d45e2e0e96c49b1427702/packages/conjure-client/src/__integTest__/tests.ts#L34-L35
https://github.com/palantir/conjure-go/blob/develop/conjure-go-verifier/ignored-test-cases.yml#L108-L111
https://github.com/palantir/conjure-python/blob/develop/conjure-python-verifier/resources/ignored_test_cases.yml#L118-L122