### PR TITLE
Upgrade Xcode version to 12.5.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
 
   cargo-build-osx:
     macos:
-      xcode: "9.4.1"
+      xcode: 12.5.0
     environment:
       GRADLE_OPTS: -Dorg.gradle.console=plain -Dorg.gradle.internal.launcher.welcomeMessageEnabled=false
       FL_OUTPUT_DIR: output

--- a/changelog/@unreleased/pr-506.v2.yml
+++ b/changelog/@unreleased/pr-506.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Upgrade Xcode version to 12.5.0
+  links:
+  - https://github.com/palantir/conjure-verification/pull/506


### PR DESCRIPTION
## Before this PR
The project uses a soon-to-be-deprecated version of Xcode. We need to move to a newer version before CircleCI removes support for the old image.

## After this PR
==COMMIT_MSG==
Upgrade Xcode version to 12.5.0
==COMMIT_MSG==

## Possible downsides?
The new version could require additional changes to the build process.

