### PR TITLE
Readme: fix link to RFC 004

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # conjure-verification
 
-Behaviour aims to satisfy [RFC 004: Consistent wire-format test cases](https://github.com/palantir/conjure/blob/develop/docs/rfc/004-consistent-wire-format-test-cases.md), but there are a few differences.
+Behaviour aims to satisfy [RFC 004: Consistent wire-format test cases](https://github.com/palantir/conjure/blob/master/docs/rfc/004-consistent-wire-format-test-cases.md), but there are a few differences.
 
 This project has two main components:
 * a [_verification server_](/docs/verification_server.md), is a reference server used to test Conjure client generators and libraries.


### PR DESCRIPTION
## Before this PR

The link from the readme to RFC 004 is wrong (it uses the wrong branch name).

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Readme: fix link to RFC 004
==COMMIT_MSG==

## Possible downsides?

Maybe we wanted to switch the default branch in palantir/conjure instead? Either way, I think it's worth fixing this unless that is imminent.